### PR TITLE
usersテーブルにpaperclip用のカラムを追加する

### DIFF
--- a/db/migrate/20161001091746_add_attachment_avatar_to_users.rb
+++ b/db/migrate/20161001091746_add_attachment_avatar_to_users.rb
@@ -1,0 +1,11 @@
+class AddAttachmentAvatarToUsers < ActiveRecord::Migration
+  def self.up
+    change_table :users do |t|
+      t.attachment :avatar
+    end
+  end
+
+  def self.down
+    remove_attachment :users, :avatar
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161001080322) do
+ActiveRecord::Schema.define(version: 20161001091746) do
 
   create_table "products", force: :cascade do |t|
     t.string   "title",      limit: 255
@@ -45,6 +45,10 @@ ActiveRecord::Schema.define(version: 20161001080322) do
     t.string   "last_sign_in_ip",        limit: 255
     t.datetime "created_at",                                      null: false
     t.datetime "updated_at",                                      null: false
+    t.string   "avatar_file_name",       limit: 255
+    t.string   "avatar_content_type",    limit: 255
+    t.integer  "avatar_file_size",       limit: 4
+    t.datetime "avatar_updated_at"
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree


### PR DESCRIPTION
ユーザーのアイコン画像をアップロードして設定できるようにします。つまり、ユーザーモデルにアイコン画像用のカラムを追加する必要があるということです。これもpaperclipを使うとほとんど自動で設定してくれます。

ユーザーモデルに追加するアイコン画像のカラム名はavatarにしましょう。カラム追加用のマイグレーションファイルはpaperclipのコマンドrails g paperclipで生成できます。

rails g paperclip モデル名 カラム名
rails g paperclip user avatar
bundle exec rake db:migrate

→avatarカラム追加
