### PR TITLE
Userモデルに画像をアップロードしてavatarを設定できるようになった。

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,11 @@ class User < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
+　has_attached_file :avatar,
+                      styles:  { medium: "300x300#", thumb: "100x100#" }
+                      #aサイズを指定するための属性はstylesです。stylesではどのような種類の画像をどの大きさで保存するか指定。vatarカラムにアップ可能な画像の大きさを指定
+  validates_attachment_content_type :avatar,
+                                      content_type: ["image/jpg","image/jpeg","image/png"] #avatarカラムにアップ可能な画像ファイルを指定
+end
+
 end


### PR DESCRIPTION
しかしこれだけではアイコン画像のアップロードはできません。Userモデルにアイコン画像の設定を記述しなくてはいけません。記述しなくてはいけない設定はhas_attached_fileとvalidates_attachment_content_typeの2つです。

has_attached_fileでは画像用のカラムのサイズやデフォルト画像、画像ファイルの保存先を設定できます。今回はサイズをだけ指定します。

validates_attachment_content_typeは画像のバリデーションを設定します。サイズや画像の種類でバリデーションが可能です。今回は画像の種類だけ指定します。
