### PR TITLE
usersテーブルにニックネームカラムを追加する

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,11 +3,9 @@ class User < ActiveRecord::Base
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
-　has_attached_file :avatar,
+  has_attached_file :avatar,
                       styles:  { medium: "300x300#", thumb: "100x100#" }
                       #aサイズを指定するための属性はstylesです。stylesではどのような種類の画像をどの大きさで保存するか指定。vatarカラムにアップ可能な画像の大きさを指定
   validates_attachment_content_type :avatar,
                                       content_type: ["image/jpg","image/jpeg","image/png"] #avatarカラムにアップ可能な画像ファイルを指定
-end
-
 end

--- a/db/migrate/20161001094237_add_nickname_to_users.rb
+++ b/db/migrate/20161001094237_add_nickname_to_users.rb
@@ -1,0 +1,5 @@
+class AddNicknameToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :nickname, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161001091746) do
+ActiveRecord::Schema.define(version: 20161001094237) do
 
   create_table "products", force: :cascade do |t|
     t.string   "title",      limit: 255
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 20161001091746) do
     t.string   "avatar_content_type",    limit: 255
     t.integer  "avatar_file_size",       limit: 4
     t.datetime "avatar_updated_at"
+    t.string   "nickname",               limit: 255
   end
 
   add_index "users", ["email"], name: "index_users_on_email", unique: true, using: :btree


### PR DESCRIPTION
paperclipによってユーザーのアイコン画像のアップロードが可能となったのでサインアップ画面でアイコン画像の設定をするビューをつくりましょう。さらにユーザーのニックネームもサインアップ画面で設定できるようにしましょう。

 作業内容

１.usersテーブルにニックネームカラムを追加する
