### PR TITLE
サインアップ画面にニックネームを入力するフォームとアイコン画像をアップロードできるフォームを作成

### DIFF
--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -17,6 +17,12 @@
           <div class="label"><%= f.label :password_confirmation %><br />
           <%= f.password_field :password_confirmation, autocomplete: "off", :placeholder => 'パスワードを入力（確認）' %></div>
 
+          <div class="label"><%= f.label :nickname %><br />
+          <%= f.text_field :nickname %></div>
+          <div class="field">
+          <%= f.file_field :avatar %>
+          </div>
+
           <div class="submit">
           <div class="actions">
           <%= f.submit %>


### PR DESCRIPTION
ニックネームはテキストフィールド、アイコン画像にはファイルフィールドと呼ばれるファイルのアップロード用のフィールドを生成します。
テキストフィールドはtext_field、ファイルフィールドはfile_fieldのフォームタグを利用することで生成できます。
テキストフィールドの作成
<%= f.text_field :カラム名 %>
