### PR TITLE
バリデーションを設定する

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,7 @@
 class User < ActiveRecord::Base
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
+   validates :nickname, presence: true
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :trackable, :validatable
   has_attached_file :avatar,

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -18,7 +18,7 @@
           <%= f.password_field :password_confirmation, autocomplete: "off", :placeholder => 'パスワードを入力（確認）' %></div>
 
           <div class="label"><%= f.label :nickname %><br />
-          <%= f.text_field :nickname %></div>
+           <%= f.text_field :nickname, placeholder: 'ニックネームを入力(必須)' %></div><!--ニックネームがないとプレースホルダーが表示される-->
           <div class="field">
           <%= f.file_field :avatar %>
           </div>


### PR DESCRIPTION
why:サインアップの際にニックネームも必須の入力項目にしたいのでニックネームが入力されていなければエラーを返すようにバリデーションを設定

さらにニックネームが必須項目であることを知らせるために以下のようにテキストフィールドにプレイスホルダーを設定

what: 
フォームの中身があるかないかを検出し、無い場合は保存を実行せず元のビューにリダイレクトします。
validates :カラム名, presence: true

フォームの中に、''で囲んだ文字をフォームの値が空の時に薄く表示しておく
 <%= f.text_field :nickname, placeholder: 'ニックネームを入力（必須）' %>
